### PR TITLE
Added a fix for system themes

### DIFF
--- a/components/TopNavBar.tsx
+++ b/components/TopNavBar.tsx
@@ -45,17 +45,20 @@ const ColorCircle = ({
 );
 
 const TopNavBar = () => {
-  const { theme, setTheme } = useTheme();
+  const { theme, resolvedTheme, setTheme } = useTheme();
   const [colorTheme, setColorTheme] = useState<ThemeName>("violet");
   const [mounted, setMounted] = useState(false);
-
   useEffect(() => {
     setMounted(true);
-    const savedColorTheme = (localStorage.getItem("color-theme") ||
-      "violet") as ThemeName;
+    const savedColorTheme = (localStorage.getItem("color-theme") || "violet") as ThemeName;
     setColorTheme(savedColorTheme);
-    applyTheme(savedColorTheme, theme === "dark");
-  }, [theme]);
+  }, []);
+
+  useEffect(() => {
+    if (!mounted) return;
+    const isDark = resolvedTheme === "dark";
+    applyTheme(colorTheme, isDark);
+  }, [resolvedTheme, colorTheme, mounted]);
 
   const applyTheme = (newColorTheme: ThemeName, isDark: boolean) => {
     const root = document.documentElement;
@@ -71,12 +74,16 @@ const TopNavBar = () => {
   const handleThemeChange = (newColorTheme: ThemeName) => {
     setColorTheme(newColorTheme);
     localStorage.setItem("color-theme", newColorTheme);
-    applyTheme(newColorTheme, theme === "dark");
+    applyTheme(newColorTheme, resolvedTheme === "dark");
   };
 
   const handleModeChange = (mode: "light" | "dark" | "system") => {
     setTheme(mode);
-    if (mode !== "system") {
+
+    if (mode === "system") {
+      const isSystemDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+      applyTheme(colorTheme, isSystemDark);
+    } else {
       applyTheme(colorTheme, mode === "dark");
     }
   };
@@ -89,14 +96,15 @@ const TopNavBar = () => {
     <nav className="text-foreground p-4 flex justify-between items-center">
       <div className="font-bold text-xl flex gap-2 items-center">
         <Image
-          src={theme === "dark" ? "/logo-dark.png" : "/logo.png"}
+          src={resolvedTheme === "dark" ? "/logo-dark.png" : "/logo.png"}
           alt="Company Wordmark"
           width={132}
           height={20}
         />
       </div>
       <div className="flex items-center gap-2">
-        {/* 
+        {/* Uncomment if color theme switching is needed */}
+        {/*
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline">


### PR DESCRIPTION
## Context

Hey! I was exploring your GitHub project and noticed an issue with theme switching — specifically, the **System** theme option wasn't working as expected. Even when the system was set to dark mode, selecting "System" would keep the app in light mode if it was previously set.

## Fix

The issue was due to the app not correctly resolving and applying the system preference when the theme was set to `"system"`.

### ✅ Fix Summary:
- Used `resolvedTheme` from `next-themes` to accurately detect the system's current theme.
- Ensured the correct color theme variables are applied immediately based on `resolvedTheme`.
- Also fixed an issue where the theme icon only changed on the second click when selecting `"system"`.

Now, switching to **System** theme reflects the actual system preference immediately and reliably.

Let me know if you'd like any changes!
